### PR TITLE
Fix Update UI Bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
@@ -87,10 +87,7 @@ public class AddRentalCommand extends Command {
         model.setPerson(clientToEdit, updatedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        if (clientToEdit.equals(model.getLastViewedClient())) {
-            model.updateVisibleRentalInformationList(updatedRentalInformationList);
-            model.setLastViewedClient(updatedClient);
-        }
+        model.setLastViewedClient(updatedClient);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatRentalInformation(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
@@ -89,6 +89,7 @@ public class AddRentalCommand extends Command {
 
         if (clientToEdit.equals(model.getLastViewedClient())) {
             model.updateVisibleRentalInformationList(updatedRentalInformationList);
+            model.setLastViewedClient(updatedClient);
         }
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatRentalInformation(toAdd)));

--- a/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRentalCommand.java
@@ -87,6 +87,10 @@ public class AddRentalCommand extends Command {
         model.setPerson(clientToEdit, updatedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
+        if (clientToEdit.equals(model.getLastViewedClient())) {
+            model.updateVisibleRentalInformationList(updatedRentalInformationList);
+        }
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatRentalInformation(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
@@ -18,6 +20,8 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        model.setLastViewedClient(null);
+        model.updateVisibleRentalInformationList(List.of());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClientCommand.java
@@ -43,6 +43,12 @@ public class DeleteClientCommand extends Command {
 
         Client clientToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(clientToDelete);
+
+        if (clientToDelete.equals(model.getLastViewedClient())) {
+            model.updateVisibleRentalInformationList(List.of());
+            model.setLastViewedClient(null);
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(clientToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
@@ -63,9 +63,12 @@ public class DeleteRentalCommand extends Command {
         Client updatedClient = new Client(targetClient.getName(), targetClient.getPhone(), targetClient.getEmail(),
                 targetClient.getTags(), rentalInformationList);
 
-        // TODO: update the rental information list in Model, waiting for implementation from "rview".
         model.setPerson(targetClient, updatedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        if (targetClient.equals(model.getLastViewedClient())) {
+            model.updateVisibleRentalInformationList(rentalInformationList);
+        }
 
         return new CommandResult(String.format(MESSAGE_DELETE_RENTAL_SUCCESS,
                 Messages.formatRentalInformation(targetRental)));

--- a/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
@@ -68,6 +68,7 @@ public class DeleteRentalCommand extends Command {
 
         if (targetClient.equals(model.getLastViewedClient())) {
             model.updateVisibleRentalInformationList(rentalInformationList);
+            model.setLastViewedClient(updatedClient);
         }
 
         return new CommandResult(String.format(MESSAGE_DELETE_RENTAL_SUCCESS,

--- a/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRentalCommand.java
@@ -66,10 +66,7 @@ public class DeleteRentalCommand extends Command {
         model.setPerson(targetClient, updatedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        if (targetClient.equals(model.getLastViewedClient())) {
-            model.updateVisibleRentalInformationList(rentalInformationList);
-            model.setLastViewedClient(updatedClient);
-        }
+        model.setLastViewedClient(updatedClient);
 
         return new CommandResult(String.format(MESSAGE_DELETE_RENTAL_SUCCESS,
                 Messages.formatRentalInformation(targetRental)));

--- a/src/main/java/seedu/address/logic/commands/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditClientCommand.java
@@ -88,6 +88,11 @@ public class EditClientCommand extends Command {
 
         model.setPerson(clientToEdit, editedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        if (clientToEdit.equals(model.getLastViewedClient())) {
+            model.setLastViewedClient(editedClient);
+        }
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedClient)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRentalCommand.java
@@ -112,6 +112,11 @@ public class EditRentalCommand extends Command {
         model.setPerson(clientToEdit, editedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
+        if (clientToEdit.equals(model.getLastViewedClient())) {
+            model.setLastViewedClient(editedClient);
+            model.updateVisibleRentalInformationList(editedClient.getRentalInformation());
+        }
+
         return new CommandResult(String.format(MESSAGE_EDIT_RENTAL_SUCCESS,
                 Messages.formatRentalInformation(editedClient.getRentalInformation().get(rentalIndex.getZeroBased()))));
     }

--- a/src/main/java/seedu/address/logic/commands/EditRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRentalCommand.java
@@ -112,10 +112,7 @@ public class EditRentalCommand extends Command {
         model.setPerson(clientToEdit, editedClient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        if (clientToEdit.equals(model.getLastViewedClient())) {
-            model.setLastViewedClient(editedClient);
-            model.updateVisibleRentalInformationList(editedClient.getRentalInformation());
-        }
+        model.setLastViewedClient(editedClient);
 
         return new CommandResult(String.format(MESSAGE_EDIT_RENTAL_SUCCESS,
                 Messages.formatRentalInformation(editedClient.getRentalInformation().get(rentalIndex.getZeroBased()))));

--- a/src/main/java/seedu/address/logic/commands/ViewRentalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewRentalCommand.java
@@ -42,6 +42,7 @@ public class ViewRentalCommand extends Command {
         Client clientToViewRentalInformation = lastShownList.get(targetIndex.getZeroBased());
         List<RentalInformation> rentalInformationListOfClient = clientToViewRentalInformation.getRentalInformation();
         model.updateVisibleRentalInformationList(rentalInformationListOfClient);
+        model.setLastViewedClient(clientToViewRentalInformation);
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_RENTAL_INFORMATION_LISTED_OVERVIEW,

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -102,7 +102,6 @@ public interface Model {
      */
     void updateVisibleRentalInformationList(List<RentalInformation> rentalInformationList);
 
-    // TODO: the methods below are temporary to fix the ui bug, change the implementation in milestone 1.4
     /**
      * Returns the last client viewed by the {@code rview} command, whose list of rental information is currently
      * displayed in the ui.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,4 +101,13 @@ public interface Model {
      * @throws NullPointerException if {@code rentalInformation} is null.
      */
     void updateVisibleRentalInformationList(List<RentalInformation> rentalInformationList);
+
+    // TODO: the methods below are temporary to fix the ui bug, change the implementation in milestone 1.4
+    /**
+     * Returns the last client viewed by the {@code rview} command, whose list of rental information is currently
+     * displayed in the ui.
+     */
+    Client getLastViewedClient();
+
+    void setLastViewedClient(Client client);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -104,9 +104,13 @@ public interface Model {
 
     /**
      * Returns the last client viewed by the {@code rview} command, whose list of rental information is currently
-     * displayed in the ui.
+     * displayed in the UI.
+     * Returns {@code null} if no client has been viewed or the last viewed client has been deleted.
      */
     Client getLastViewedClient();
 
+    /**
+     * Sets the last viewed client of this model.
+     */
     void setLastViewedClient(Client client);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -154,7 +154,6 @@ public class ModelManager implements Model {
         visibleRentalInformationList.setAll(rentalInformationList);
     }
 
-    // TODO: change the implementation of this in milestone 1.4
     @Override
     public Client getLastViewedClient() {
         return lastViewedClient;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,6 +26,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Client> filteredClients;
     private final ObservableList<RentalInformation> visibleRentalInformationList;
+    private Client lastViewedClient = null;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -151,6 +152,17 @@ public class ModelManager implements Model {
     public void updateVisibleRentalInformationList(List<RentalInformation> rentalInformationList) {
         requireNonNull(rentalInformationList);
         visibleRentalInformationList.setAll(rentalInformationList);
+    }
+
+    // TODO: change the implementation of this in milestone 1.4
+    @Override
+    public Client getLastViewedClient() {
+        return lastViewedClient;
+    }
+
+    @Override
+    public void setLastViewedClient(Client client) {
+        this.lastViewedClient = client;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClientCommandTest.java
@@ -175,6 +175,16 @@ public class AddClientCommandTest {
         public void updateVisibleRentalInformationList(List<RentalInformation> rentalInformationList) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public Client getLastViewedClient() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setLastViewedClient(Client client) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddRentalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRentalCommandTest.java
@@ -188,6 +188,16 @@ public class AddRentalCommandTest {
         public void updateVisibleRentalInformationList(List<RentalInformation> rentalInformationList) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public Client getLastViewedClient() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setLastViewedClient(Client client) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**
@@ -196,6 +206,7 @@ public class AddRentalCommandTest {
     private class ModelStubAcceptingRentalInformationAdded extends ModelStub {
         final ArrayList<Client> originalList = new ArrayList<>(List.of(new PersonBuilder().build()));
         final FilteredList<Client> filteredList = new FilteredList<>(FXCollections.observableList(originalList));
+        private Client lastViewedClient = null;
 
         @Override
         public boolean hasPerson(Client client) {
@@ -238,6 +249,16 @@ public class AddRentalCommandTest {
         @Override
         public void updateFilteredPersonList(Predicate<Client> predicate) {
             filteredList.setPredicate(predicate);
+        }
+
+        @Override
+        public Client getLastViewedClient() {
+            return lastViewedClient;
+        }
+
+        @Override
+        public void setLastViewedClient(Client client) {
+            lastViewedClient = client;
         }
     }
 


### PR DESCRIPTION
Adds a field in `Model` to keep track of the last viewed client. This field is updated when commands involving rental information are executed.

Commands updated:
- `rview`
- `radd`
- `rdelete`
- `cdelete`
- `clear`
- `redit`
- `cedit`

Fixes #127 