### PR TITLE
Standardise naming scheme for `PersonListCard` and `RentalInformationListCard`

### DIFF
--- a/docs/diagrams/UiClassDiagram.puml
+++ b/docs/diagrams/UiClassDiagram.puml
@@ -12,7 +12,7 @@ Class MainWindow
 Class HelpWindow
 Class ResultDisplay
 Class PersonListPanel
-Class PersonCard
+Class PersonListCard
 Class StatusBarFooter
 Class CommandBox
 }
@@ -36,18 +36,18 @@ MainWindow *-down-> "1" PersonListPanel
 MainWindow *-down-> "1" StatusBarFooter
 MainWindow --> "0..1" HelpWindow
 
-PersonListPanel -down-> "*" PersonCard
+PersonListPanel -down-> "*" PersonListCard
 
 MainWindow -left-|> UiPart
 
 ResultDisplay --|> UiPart
 CommandBox --|> UiPart
 PersonListPanel --|> UiPart
-PersonCard --|> UiPart
+PersonListCard --|> UiPart
 StatusBarFooter --|> UiPart
 HelpWindow --|> UiPart
 
-PersonCard ..> Model
+PersonListCard ..> Model
 UiManager -right-> Logic
 MainWindow -left-> Logic
 

--- a/src/main/java/seedu/address/ui/PersonListCard.java
+++ b/src/main/java/seedu/address/ui/PersonListCard.java
@@ -42,7 +42,7 @@ public class PersonListCard extends UiPart<Region> {
     private FlowPane tags;
 
     /**
-     * Creates a {@code PersonCode} with the given {@code Client} and index to display.
+     * Creates a {@code PersonListCard } with the given {@code Client} and index to display.
      */
     public PersonListCard(Client client, int displayedIndex) {
         super(FXML);

--- a/src/main/java/seedu/address/ui/PersonListCard.java
+++ b/src/main/java/seedu/address/ui/PersonListCard.java
@@ -12,7 +12,7 @@ import seedu.address.model.client.Client;
 /**
  * An UI component that displays information of a {@code Client}.
  */
-public class PersonCard extends UiPart<Region> {
+public class PersonListCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
 
@@ -44,7 +44,7 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Client} and index to display.
      */
-    public PersonCard(Client client, int displayedIndex) {
+    public PersonListCard(Client client, int displayedIndex) {
         super(FXML);
         this.client = client;
         id.setText(displayedIndex + ". ");

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -30,7 +30,7 @@ public class PersonListPanel extends UiPart<Region> {
     }
 
     /**
-     * Custom {@code ListCell} that displays the graphics of a {@code Client} using a {@code PersonCard}.
+     * Custom {@code ListCell} that displays the graphics of a {@code Client} using a {@code PersonListCard}.
      */
     class PersonListViewCell extends ListCell<Client> {
         @Override
@@ -41,7 +41,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(client, getIndex() + 1).getRoot());
+                setGraphic(new PersonListCard(client, getIndex() + 1).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/RentalInformationListCard.java
+++ b/src/main/java/seedu/address/ui/RentalInformationListCard.java
@@ -9,9 +9,9 @@ import seedu.address.model.rentalinformation.RentalInformation;
 /**
  * A UI component that displays information of a {@code RentalInformation}.
  */
-public class RentalInformationCard extends UiPart<Region> {
+public class RentalInformationListCard extends UiPart<Region> {
 
-    private static final String FXML = "RentalInformationCard.fxml";
+    private static final String FXML = "RentalInformationListCard.fxml";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -45,9 +45,9 @@ public class RentalInformationCard extends UiPart<Region> {
     private Label ownerName;
 
     /**
-     * Creates a {@code RentalInformationCard} with the given {@code RentalInformation} and index to display.
+     * Creates a {@code RentalInformationListCard} with the given {@code RentalInformation} and index to display.
      */
-    public RentalInformationCard(RentalInformation rentalInformation, int displayedIndex) {
+    public RentalInformationListCard(RentalInformation rentalInformation, int displayedIndex) {
         super(FXML);
         this.rentalInformation = rentalInformation;
         id.setText(displayedIndex + ". ");

--- a/src/main/java/seedu/address/ui/RentalInformationListPanel.java
+++ b/src/main/java/seedu/address/ui/RentalInformationListPanel.java
@@ -76,7 +76,7 @@ public class RentalInformationListPanel extends UiPart<Region> {
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code RentalInformation} using a
-     * {@code RentalInformationCard}.
+     * {@code RentalInformationListCard}.
      */
     class RentalInformationListViewCell extends ListCell<RentalInformation> {
         @Override
@@ -87,7 +87,7 @@ public class RentalInformationListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new RentalInformationCard(rentalInformation, getIndex() + 1).getRoot());
+                setGraphic(new RentalInformationListCard(rentalInformation, getIndex() + 1).getRoot());
             }
         }
     }


### PR DESCRIPTION
Replaced all occurrences of `PersonCard` and `RentalInformationCard` with `PersonListCard` and `RentalInformationListCard` respectively.