### PR TITLE
Update `equals()` in `ModelManager` and fix integration tests that were affected

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -212,7 +213,8 @@ public class ModelManager implements Model {
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredClients.equals(otherModelManager.filteredClients)
                 && clients.equals(otherModelManager.clients)
-                && visibleRentalInformationList.equals(otherModelManager.visibleRentalInformationList);
+                && visibleRentalInformationList.equals(otherModelManager.visibleRentalInformationList)
+                && Objects.equals(lastViewedClient.get(), otherModelManager.lastViewedClient.get());
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -211,7 +211,8 @@ public class ModelManager implements Model {
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredClients.equals(otherModelManager.filteredClients)
-                && clients.equals(otherModelManager.clients);
+                && clients.equals(otherModelManager.clients)
+                && visibleRentalInformationList.equals(otherModelManager.visibleRentalInformationList);
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -210,6 +210,7 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
+                && filteredClients.equals(otherModelManager.filteredClients)
                 && clients.equals(otherModelManager.clients);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -214,7 +214,8 @@ public class ModelManager implements Model {
                 && filteredClients.equals(otherModelManager.filteredClients)
                 && clients.equals(otherModelManager.clients)
                 && visibleRentalInformationList.equals(otherModelManager.visibleRentalInformationList)
-                && Objects.equals(lastViewedClient.get(), otherModelManager.lastViewedClient.get());
+                && Objects.equals(lastViewedClient.get(), otherModelManager.lastViewedClient.get())
+                && commandHistoryStorage.equals(otherModelManager.commandHistoryStorage);
     }
 
 }

--- a/src/main/java/seedu/address/storage/CommandHistoryStorage.java
+++ b/src/main/java/seedu/address/storage/CommandHistoryStorage.java
@@ -187,6 +187,7 @@ public class CommandHistoryStorage {
     public void setCommandHistoryFilePath(Path path) {
         commandHistoryFilePath = path;
     }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -197,9 +198,7 @@ public class CommandHistoryStorage {
         }
         CommandHistoryStorage other = (CommandHistoryStorage) obj;
 
-        return commandHistoryFilePath.equals(other.commandHistoryFilePath)
-                && lines.equals(other.lines)
-                && currentLineNumber == other.currentLineNumber
+        return currentLineNumber == other.currentLineNumber
                 && previousTotalLines == other.previousTotalLines;
     }
 }

--- a/src/main/java/seedu/address/storage/CommandHistoryStorage.java
+++ b/src/main/java/seedu/address/storage/CommandHistoryStorage.java
@@ -187,4 +187,19 @@ public class CommandHistoryStorage {
     public void setCommandHistoryFilePath(Path path) {
         commandHistoryFilePath = path;
     }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CommandHistoryStorage)) {
+            return false;
+        }
+        CommandHistoryStorage other = (CommandHistoryStorage) obj;
+
+        return commandHistoryFilePath.equals(other.commandHistoryFilePath)
+                && lines.equals(other.lines)
+                && currentLineNumber == other.currentLineNumber
+                && previousTotalLines == other.previousTotalLines;
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteRentalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteRentalCommandTest.java
@@ -12,6 +12,9 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_RENTAL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithRental;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -46,6 +49,8 @@ public class DeleteRentalCommandTest {
                 .withRentalInformation(secondClient.getRentalInformation().get(INDEX_SECOND_RENTAL.getZeroBased()))
                 .build();
         expectedModel.setPerson(secondClient, editedClient);
+        List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
+        expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
 
         assertCommandPromptsSuccess(deleteRentalCommand, model, expectedPrompt, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteRentalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteRentalCommandTest.java
@@ -45,10 +45,13 @@ public class DeleteRentalCommandTest {
                 Messages.formatRentalInformation(rentalToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
         Client editedClient = new PersonBuilder(secondClient)
                 .withRentalInformation(secondClient.getRentalInformation().get(INDEX_SECOND_RENTAL.getZeroBased()))
                 .build();
         expectedModel.setPerson(secondClient, editedClient);
+        expectedModel.setLastViewedClient(editedClient);
+
         List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
         expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
 
@@ -86,8 +89,10 @@ public class DeleteRentalCommandTest {
                 Messages.formatRentalInformation(rentalToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
         Client editedClient = new PersonBuilder(firstClient).withRentalInformation().build();
         expectedModel.setPerson(firstClient, editedClient);
+        expectedModel.setLastViewedClient(editedClient);
 
         assertCommandPromptsSuccess(deleteRentalCommand, model, expectedPrompt, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditRentalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditRentalCommandTest.java
@@ -17,6 +17,9 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_RENTAL;
 import static seedu.address.testutil.TypicalPersons.ALICE_WITH_RENTAL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithRental;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -52,6 +55,9 @@ public class EditRentalCommandTest {
                 .build();
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedClient);
 
+        List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
+        expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
+
         assertCommandSuccess(editRentalCommand, model, expectedMessage, expectedModel);
     }
 
@@ -78,6 +84,9 @@ public class EditRentalCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastClient, editedClient);
 
+        List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
+        expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
+
         assertCommandSuccess(editRentalCommand, model, expectedMessage, expectedModel);
     }
 
@@ -93,6 +102,9 @@ public class EditRentalCommandTest {
                 Messages.formatRentalInformation(editedRentalInformation));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
+        expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
 
         assertCommandSuccess(editRentalCommand, model, expectedMessage, expectedModel);
     }
@@ -118,6 +130,9 @@ public class EditRentalCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedClient);
+
+        List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
+        expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
 
         assertCommandSuccess(editRentalCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/EditRentalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditRentalCommandTest.java
@@ -51,9 +51,11 @@ public class EditRentalCommandTest {
                 Messages.formatRentalInformation(editedRentalInformation));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
         Client editedClient = new PersonBuilder(ALICE_WITH_RENTAL).withRentalInformation(editedRentalInformation)
                 .build();
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedClient);
+        expectedModel.setLastViewedClient(editedClient);
 
         List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
         expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
@@ -82,7 +84,9 @@ public class EditRentalCommandTest {
                 Messages.formatRentalInformation(editedRentalInformation));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
         expectedModel.setPerson(lastClient, editedClient);
+        expectedModel.setLastViewedClient(editedClient);
 
         List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
         expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
@@ -102,6 +106,8 @@ public class EditRentalCommandTest {
                 Messages.formatRentalInformation(editedRentalInformation));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        expectedModel.setLastViewedClient(editedClient);
 
         List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
         expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);
@@ -129,7 +135,9 @@ public class EditRentalCommandTest {
                 Messages.formatRentalInformation(editeRentalInformation));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedClient);
+        expectedModel.setLastViewedClient(editedClient);
 
         List<RentalInformation> editedRentalInformationList = new ArrayList<>(editedClient.getRentalInformation());
         expectedModel.updateVisibleRentalInformationList(editedRentalInformationList);

--- a/src/test/java/seedu/address/storage/CommandHistoryStorageTest.java
+++ b/src/test/java/seedu/address/storage/CommandHistoryStorageTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileWriter;
@@ -131,5 +132,28 @@ public class CommandHistoryStorageTest {
 
         assertEquals(2, lineCount);
         clearFile();
+    }
+
+    @Test
+    void testEquals_sameInstance() {
+        assertTrue(commandHistoryStorage.equals(commandHistoryStorage), "An instance should be equal to itself");
+    }
+
+    @Test
+    void testEquals_null() {
+        assertFalse(commandHistoryStorage.equals(null), "An instance should not be equal to null");
+    }
+
+    @Test
+    void testEquals_differentClass() {
+        assertFalse(commandHistoryStorage.equals("some string"), "An instance should not be equal to an object of a different class");
+    }
+
+    @Test
+    void testEquals_identicalFields() {
+        CommandHistoryStorage anotherInstance = new CommandHistoryStorage();
+        anotherInstance.setCommandHistoryFilePath(testFilePath);
+
+        assertTrue(commandHistoryStorage.equals(anotherInstance), "Instances with identical fields should be equal");
     }
 }

--- a/src/test/java/seedu/address/storage/CommandHistoryStorageTest.java
+++ b/src/test/java/seedu/address/storage/CommandHistoryStorageTest.java
@@ -136,7 +136,8 @@ public class CommandHistoryStorageTest {
 
     @Test
     void testEquals_sameInstance() {
-        assertTrue(commandHistoryStorage.equals(commandHistoryStorage), "An instance should be equal to itself");
+        assertTrue(commandHistoryStorage.equals(commandHistoryStorage),
+                "An instance should be equal to itself");
     }
 
     @Test
@@ -146,7 +147,8 @@ public class CommandHistoryStorageTest {
 
     @Test
     void testEquals_differentClass() {
-        assertFalse(commandHistoryStorage.equals("some string"), "An instance should not be equal to an object of a different class");
+        assertFalse(commandHistoryStorage.equals("some string"),
+                "An instance should not be equal to an object of a different class");
     }
 
     @Test
@@ -154,6 +156,7 @@ public class CommandHistoryStorageTest {
         CommandHistoryStorage anotherInstance = new CommandHistoryStorage();
         anotherInstance.setCommandHistoryFilePath(testFilePath);
 
-        assertTrue(commandHistoryStorage.equals(anotherInstance), "Instances with identical fields should be equal");
+        assertTrue(commandHistoryStorage.equals(anotherInstance),
+                "Instances with identical fields should be equal");
     }
 }


### PR DESCRIPTION
Resolves #199 

- The changes to `equals()` in `ModelManager` caused integration tests in `DeleteRentalCommandTest.java` and `EditRentalCommandTest.java` to fail.
  - This was because the `lastViewedClient` and `visibleRentalInformationList` fields of `expectedModel` were not updated.
  - The behavior of `expectedModel` in certain tests within `DeleteRentalCommandTest.java` and `EditRentalCommandTest.java` has been updated to fix this issue.
    - See commits 65e60ca700a60f3e5db9ad8d2b093e3628efb8b6 and 399d117d5c9f4d017c14906569d987cbe30c7df2 for more details.

- Implemented `equals()` in `CommandHistoryStorage` as it is required for `equals()` in `ModelManager`.
  - See commit 30ba69a84a4821a9de1310483f51c9131dfecddf for more details.

