### PR TITLE
Fix YAML frontmatter indentation errors in docs

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -1,6 +1,6 @@
 ---
-  layout: default.md
-  title: "About Us"
+layout: default.md
+title: "About Us"
 ---
 
 # About Us

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,6 @@
 ---
-  layout: default.md
-  title: "Configuration guide"
+layout: default.md
+title: "Configuration guide"
 ---
 
 # Configuration guide

--- a/docs/DevOps.md
+++ b/docs/DevOps.md
@@ -1,7 +1,7 @@
 ---
-  layout: default.md
-  title: "DevOps guide"
-  pageNav: 3
+layout: default.md
+title: "DevOps guide"
+pageNav: 3
 ---
 
 # DevOps guide

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,7 +1,7 @@
 ---
-  layout: default.md
-    title: "Developer Guide"
-    pageNav: 3
+layout: default.md
+title: "Developer Guide"
+pageNav: 3
 ---
 
 # TrueRental Developer Guide

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -1,7 +1,7 @@
 ---
-  layout: default.md
-  title: "Documentation guide"
-  pageNav: 3
+layout: default.md
+title: "Documentation guide"
+pageNav: 3
 ---
 
 # Documentation Guide

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,6 +1,6 @@
 ---
-  layout: default.md
-  title: "Logging guide"
+layout: default.md
+title: "Logging guide"
 ---
 
 # Logging guide

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,7 +1,7 @@
 ---
-  layout: default.md
-  title: "Testing guide"
-  pageNav: 3
+layout: default.md
+title: "Testing guide"
+pageNav: 3
 ---
 
 # Testing guide

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,7 +1,7 @@
 ---
-  layout: default.md
-  title: "User Guide"
-  pageNav: 3
+layout: default.md
+title: "User Guide"
+pageNav: 3
 ---
 
 # TrueRental User Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-  layout: default.md
-  title: ""
+layout: default.md
+title: ""
 ---
 
 # TrueRental


### PR DESCRIPTION
Resolves #264 

This prevents an error from occurring when serving the docs using MarkBind.